### PR TITLE
Handle dependencies from Windows System32 directory

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Coveo.Cdf.DllUtil;
 
 namespace ListDependencies
@@ -31,12 +32,23 @@ namespace ListDependencies
         static bool verbose = false;
         static bool internalOnly = false;
 
+        static HashSet<string> FoundInCurrentDir = new HashSet<string>();
+        static HashSet<string> FoundInWindowsDir = new HashSet<string>();
+        static HashSet<string> NotFound = new HashSet<string>();
+
+        // 
+        // https://regex101.com/r/CKvCnx/2
+        static string ApiSetPattern = "(api-|ext-)[a-zA-Z0-9-]*(l[0-9]-[0-9]-[0-9])";
+        static Regex ApiSetRegex;
+
         static void Main(string[] args)
         {
             if (args == null || string.IsNullOrWhiteSpace(args[0])) {
                 Console.WriteLine(USAGE);
                 Environment.Exit(1);
             }
+
+            ApiSetRegex = new Regex(ApiSetPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
             FileInfo filename;
             if (File.Exists(args[0])) {
@@ -49,23 +61,28 @@ namespace ListDependencies
             verbose = args.Length > 1 && args[1] == "verbose";
             internalOnly = args.Length > 1 && args[1] == "internal";
 
-            var dict = new HashSet<string>();
-            var unable = new HashSet<string>();
-            AddDependencies(0, dict, unable, filename.Name);
+            AddDependencies(0, filename.Name);
 
             StringBuilder output = new StringBuilder();
 
             if (!internalOnly) {
-                output.AppendLine("\nNot in directory:");
-                foreach (var key in unable.OrderBy(x => x)) {
-                    output.AppendLine("  " + key);
-                }
-                output.AppendLine("\nDependencies:");
-                foreach (var key in dict.OrderBy(x => x)) {
+                output.AppendLine("\nDependencies in current directory:");
+                foreach (var key in FoundInCurrentDir.OrderBy(x => x)) {
                     output.AppendLine("  " + ResolveFileName(key));
                 }
-            } else {
-                foreach (var key in dict.OrderBy(x => x)) {
+                output.AppendLine("\nDependencies in Windows System32 directory:");
+                foreach (var key in FoundInWindowsDir.OrderBy(x => x))
+                {
+                    output.AppendLine("  " + ResolveFileName(key));
+                }
+                output.AppendLine("\nNot found:");
+                foreach (var key in NotFound.OrderBy(x => x))
+                {
+                    output.AppendLine("  " + key);
+                }
+            }
+            else {
+                foreach (var key in FoundInCurrentDir.OrderBy(x => x)) {
                     FileInfo dep = new FileInfo(ResolveFileName(key));
                     output.AppendLine(dep.FullName);
                 }
@@ -91,15 +108,22 @@ namespace ListDependencies
             return p_FileName;
         }
 
-        static void AddDependencies(int p_Level, HashSet<string> p_Dict, HashSet<string> p_Unable, string p_Filename)
+        static void AddDependencies(int p_Level, string p_Filename)
         {
-            if (p_Dict.Contains(p_Filename) || p_Unable.Contains(p_Filename)) {
+            if (FoundInCurrentDir.Contains(p_Filename) || FoundInWindowsDir.Contains(p_Filename) || NotFound.Contains(p_Filename)) {
                 return;
             }
-            if (verbose) {
+            if( ApiSetRegex.IsMatch(p_Filename))
+            {
+                return;
+            }
+
+            if (verbose)
+            {
                 Console.WriteLine(new string(' ', p_Level * 2) + p_Filename);
             }
-            p_Dict.Add(p_Filename);
+
+            FoundInCurrentDir.Add(p_Filename);
             bool hasDllExt = p_Filename.EndsWith(DLL_EXT, StringComparison.InvariantCultureIgnoreCase) ||
                              p_Filename.EndsWith(PYD_EXT, StringComparison.InvariantCultureIgnoreCase) ||
                              p_Filename.EndsWith(EXE_EXT, StringComparison.InvariantCultureIgnoreCase);
@@ -107,17 +131,24 @@ namespace ListDependencies
                 using (var dllReader = new DllReader(hasDllExt ? p_Filename : p_Filename + DLL_EXT)) {
                     if (dllReader.IsPureClr) {
                         foreach (var ass in dllReader.AssemblyReferences) {
-                            AddDependencies(p_Level + 1, p_Dict, p_Unable, ass.Name);
+                            AddDependencies(p_Level + 1, ass.Name);
                         }
                     } else {
                         foreach (var dll in dllReader.DllDependencies) {
-                            AddDependencies(p_Level + 1, p_Dict, p_Unable, dll.Name);
+                            AddDependencies(p_Level + 1, dll.Name);
                         }
                     }
                 }
             } catch (Exception) {
-                p_Dict.Remove(p_Filename);
-                p_Unable.Add(p_Filename);
+                FoundInCurrentDir.Remove(p_Filename);
+                if(File.Exists( Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), p_Filename)))
+                {
+                    FoundInWindowsDir.Add(p_Filename);
+                }
+                else
+                {
+                    NotFound.Add(p_Filename);
+                }
             }
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -36,7 +36,7 @@ namespace ListDependencies
         static HashSet<string> FoundInWindowsDir = new HashSet<string>();
         static HashSet<string> NotFound = new HashSet<string>();
 
-        // 
+        // See https://docs.microsoft.com/en-us/windows/win32/apiindex/windows-apisets
         // https://regex101.com/r/CKvCnx/2
         static string ApiSetPattern = "(api-|ext-)[a-zA-Z0-9-]*(l[0-9]-[0-9]-[0-9])";
         static Regex ApiSetRegex;
@@ -110,11 +110,10 @@ namespace ListDependencies
 
         static void AddDependencies(int p_Level, string p_Filename)
         {
-            if (FoundInCurrentDir.Contains(p_Filename) || FoundInWindowsDir.Contains(p_Filename) || NotFound.Contains(p_Filename)) {
-                return;
-            }
-            if( ApiSetRegex.IsMatch(p_Filename))
-            {
+            if (FoundInCurrentDir.Contains(p_Filename)
+                || FoundInWindowsDir.Contains(p_Filename) 
+                || NotFound.Contains(p_Filename) 
+                || ApiSetRegex.IsMatch(p_Filename) ) {
                 return;
             }
 


### PR DESCRIPTION
and also handle API sets correctly.
The objective is to remove false-negatives:  files that were reported "not in directory", but which are not an error; that is they do not need to be packaged and shipped with the application.
This PR handles 2 cases:
- The dependency is present in the Windows/System32 directory.
- The dependency is in fact an [API set](https://docs.microsoft.com/en-us/windows/win32/apiindex/windows-apisets).

Example _previous_ output:
```
Not in directory:
  ADVAPI32.dll
  api-ms-win-crt-conio-l1-1-0.dll
  api-ms-win-crt-convert-l1-1-0.dll
  api-ms-win-crt-environment-l1-1-0.dll
  api-ms-win-crt-filesystem-l1-1-0.dll
  api-ms-win-crt-heap-l1-1-0.dll
  api-ms-win-crt-locale-l1-1-0.dll
  api-ms-win-crt-math-l1-1-0.dll
  api-ms-win-crt-process-l1-1-0.dll
  api-ms-win-crt-runtime-l1-1-0.dll
  api-ms-win-crt-stdio-l1-1-0.dll
  api-ms-win-crt-string-l1-1-0.dll
  api-ms-win-crt-time-l1-1-0.dll
  api-ms-win-crt-utility-l1-1-0.dll
  bcrypt.dll
  CONCRT140.dll
  CRYPT32.dll
  GDI32.dll
  IPHLPAPI.DLL
  KERNEL32.dll
  MPR.dll
  msvcrt.dll
  MSWSOCK.dll
  NETAPI32.dll
  ODBC32.dll
  ole32.dll
  OLEAUT32.dll
  RPCRT4.dll
  Secur32.dll
  SHELL32.dll
  SHLWAPI.dll
  USER32.dll
  USERENV.dll
  VERSION.dll
  WINHTTP.dll
  WININET.dll
  WLDAP32.dll
  WS2_32.dll

Dependencies:
  aws-c-common.dll
  aws-c-event-stream.dll
  aws-checksums.dll
  aws-cpp-sdk-core.dll
  aws-cpp-sdk-s3.dll
  aws-cpp-sdk-sqs.dll
  aws-cpp-sdk-sts.dll
  blosc.dll
  boost_chrono-vc141-mt-x64-1_68.dll
  boost_filesystem-vc141-mt-x64-1_68.dll
  boost_regex-vc141-mt-x64-1_68.dll
  boost_system-vc141-mt-x64-1_68.dll
  boost_thread-vc141-mt-x64-1_68.dll
  CDFLogBlade.dll
  CDFLogDefinition.dll
  CDFNodeProcess.exe
  CDFNodes.dll
  CDFNodesHelper.dll
  CGL.dll
  CGLAlgo.dll
  CGLAWS.dll
  CGLBase.dll
  CGLCOMHelper.dll
  CGLCompression.dll
  CGLEncoding.dll
  CGLFile.dll
  CGLNetworkHelper.dll
  CGLNetworkProtocol.dll
  CGLSecurity.dll
  CGLService.dll
  CGLWindows.dll
  CGLXML.dll
  Cmf.dll
  dbghelp.dll
  hiredis.dll
  hiredis_ssl.dll
  icudt66.dll
  icuuc66.dll
  libcrypto-1_1-x64.dll
  libcurl.dll
  libssl-1_1-x64.dll
  log4cxx.dll
  MSVCP140.dll
  python36.dll
  rabbitmq.4.dll
  SimpleAmqpClient.2.dll
  tbb.dll
  VCRUNTIME140.dll
  VCRUNTIME140_1.dll
  xerces-c_3_2.dll
```

same example, _new_ output:
```
Dependencies in current directory:
  aws-c-common.dll
  aws-c-event-stream.dll
  aws-checksums.dll
  aws-cpp-sdk-core.dll
  aws-cpp-sdk-s3.dll
  aws-cpp-sdk-sqs.dll
  aws-cpp-sdk-sts.dll
  blosc.dll
  boost_chrono-vc141-mt-x64-1_68.dll
  boost_filesystem-vc141-mt-x64-1_68.dll
  boost_regex-vc141-mt-x64-1_68.dll
  boost_system-vc141-mt-x64-1_68.dll
  boost_thread-vc141-mt-x64-1_68.dll
  CDFLogBlade.dll
  CDFLogDefinition.dll
  CDFNodeProcess.exe
  CDFNodes.dll
  CDFNodesHelper.dll
  CGL.dll
  CGLAlgo.dll
  CGLAWS.dll
  CGLBase.dll
  CGLCOMHelper.dll
  CGLCompression.dll
  CGLEncoding.dll
  CGLFile.dll
  CGLNetworkHelper.dll
  CGLNetworkProtocol.dll
  CGLSecurity.dll
  CGLService.dll
  CGLWindows.dll
  CGLXML.dll
  Cmf.dll
  dbghelp.dll
  hiredis.dll
  hiredis_ssl.dll
  icudt66.dll
  icuuc66.dll
  libcrypto-1_1-x64.dll
  libcurl.dll
  libssl-1_1-x64.dll
  log4cxx.dll
  MSVCP140.dll
  python36.dll
  rabbitmq.4.dll
  SimpleAmqpClient.2.dll
  tbb.dll
  VCRUNTIME140.dll
  VCRUNTIME140_1.dll
  xerces-c_3_2.dll

Dependencies in Windows System32 directory:
  ADVAPI32.dll
  bcrypt.dll
  CONCRT140.dll
  CRYPT32.dll
  GDI32.dll
  IPHLPAPI.DLL
  KERNEL32.dll
  MPR.dll
  msvcrt.dll
  MSWSOCK.dll
  NETAPI32.dll
  ODBC32.dll
  ole32.dll
  OLEAUT32.dll
  RPCRT4.dll
  Secur32.dll
  SHELL32.dll
  SHLWAPI.dll
  USER32.dll
  USERENV.dll
  VERSION.dll
  WINHTTP.dll
  WININET.dll
  WLDAP32.dll
  WS2_32.dll

Not found:

```
